### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Wiki React Redux is a small full-stack app: an Express + Mongoose REST API
+(`server.js`, `models/`) and a React 16 / Redux frontend bundled by Webpack
+(`src/`, `public/`). See `README.md` for the full overview, API endpoints, and
+env vars.
+
+### Running the app (dev)
+- Use the in-memory MongoDB — no local Mongo install is needed. The `yarn dev`
+  script already sets `USE_IN_MEMORY_DB=true` and runs both processes via
+  `concurrently`.
+- To run the two processes separately (e.g. for cleaner logs):
+  - API server: `USE_IN_MEMORY_DB=true yarn server` → http://localhost:3001
+  - Frontend: `yarn start` → http://localhost:3000
+- The webpack dev server proxies `/api/*` to the API on port 3001, so the
+  frontend must reach the API through port 3000 (not 3001 directly).
+- Gotcha: without `USE_IN_MEMORY_DB=true`, `yarn server` tries to connect to a
+  local `mongod` at `127.0.0.1:27017` and exits with an error since none is
+  installed here. Always export that var (or use `yarn dev`).
+- `yarn start` passes `--open`; there is no GUI browser auto-launch in this
+  environment, so it simply logs the URL — this is expected, not an error.
+- `mongodb-memory-server` downloads a MongoDB binary on first run (cached
+  afterward under the home dir); the first `yarn server` start can take longer.
+
+### Lint / test / build
+- No lint script is configured. `.jshintrc` exists but `jshint` is not a
+  dependency and there is no `lint` npm script.
+- No working automated test runner is configured. `src/components/App.test.js`
+  uses Jest-style globals, but Jest is not installed and there is no `test`
+  script; `yarn test` will fail.
+- `yarn build` (production bundle via `webpack.prod.js`) works. The dev build
+  emits benign warnings only (Dart Sass "legacy JS API" deprecation and one
+  `SET_LOADING` unused-import warning) — these are pre-existing, not errors.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Wiki React Redux app (Express + Mongoose API and React 16 / Redux / Webpack frontend) and documents durable startup guidance for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run the app in dev (in-memory MongoDB via `USE_IN_MEMORY_DB=true`), the `/api` proxy behavior, and the lint/test/build state.
- Update script (VM startup dependency refresh): `yarn install`.

## Environment verification

- `yarn install` — dependencies install cleanly.
- API server (`USE_IN_MEMORY_DB=true yarn server`) starts on port 3001 with in-memory MongoDB.
- Frontend (`yarn start`) compiles and serves on port 3000; `/api` proxy to 3001 works.
- `yarn build` — production bundle builds (warnings only).

### Hello-world (core create/read)

Created and read back a wiki article through the running API:

[hello_world_api.log](https://cursor.com/agents/bc-eb4a0264-0c59-431e-82a5-13bae82a1c3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_api.log)

Frontend dev server renders the app (Add Wiki form):

[Add Wiki form rendered by frontend dev server](https://cursor.com/agents/bc-eb4a0264-0c59-431e-82a5-13bae82a1c3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_add_form.webp)

## Pre-existing bug (not an environment issue)

The frontend crashes after submitting the create form: `SET_LOADING is not defined`. The `SET_LOADING` action-type constant is used in `src/actions/index.js` (`setLoading`) and imported in `src/reducers/index.js`, but it is never declared/exported in `src/actions/index.js` (webpack also emits a matching `export 'SET_LOADING' ... was not found` warning). The form's POST to the API actually succeeds; the crash happens in the subsequent `loadWikis` refresh. This is application code, so it was left unmodified per the environment-setup scope.

[Frontend error dialog: SET_LOADING is not defined](https://cursor.com/agents/bc-eb4a0264-0c59-431e-82a5-13bae82a1c3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_set_loading_bug.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4a0264-0c59-431e-82a5-13bae82a1c3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4a0264-0c59-431e-82a5-13bae82a1c3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

