### PR TITLE
Add Render deployment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "start": "webpack serve --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
+    "start:prod": "NODE_ENV=production node server.js",
     "server": "nodemon server.js",
     "dev": "USE_IN_MEMORY_DB=true concurrently \"yarn server\" \"yarn start\""
   },

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: wiki-react-redux
+    runtime: node
+    plan: free
+    region: oregon
+    branch: master
+    buildCommand: yarn install && yarn build
+    startCommand: node server.js
+    healthCheckPath: /api
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: MONGODB_URI
+        sync: false

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const express = require("express");
 const bodyParser = require("body-parser");
 const mongoose = require("mongoose");
@@ -99,6 +100,14 @@ router.delete("/wikis/:id", async (req, res) => {
 
 app.use("/api", router);
 
+if (process.env.NODE_ENV === "production") {
+  const distPath = path.join(__dirname, "dist");
+  app.use(express.static(distPath));
+  app.get("*", (req, res) => {
+    res.sendFile(path.join(distPath, "index.html"));
+  });
+}
+
 async function connectDatabase() {
   if (useInMemoryDb) {
     const { MongoMemoryServer } = require("mongodb-memory-server");
@@ -115,8 +124,8 @@ async function connectDatabase() {
 
 connectDatabase()
   .then(() => {
-    app.listen(port, () => {
-      console.log(`API server started on port: ${port}`);
+    app.listen(port, "0.0.0.0", () => {
+      console.log(`Server started on port: ${port}`);
     });
   })
   .catch(error => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds production deployment support for Render, serving the React frontend and Express API from a single web service.

## Changes

- **`server.js`**: Serves built static assets from `dist/` in production, with SPA fallback for React Router. Binds to `0.0.0.0` for Render port binding.
- **`render.yaml`**: Blueprint defining a free-tier Node web service with build/start commands and health check at `/api`.
- **`package.json`**: Adds `start:prod` script for local production testing.

## Deployment

This app requires an external MongoDB instance (e.g. [MongoDB Atlas](https://www.mongodb.com/atlas)). Set `MONGODB_URI` in the Render Dashboard before deploying.

### Option A: Blueprint (recommended)

1. Merge this PR
2. Open the Blueprint deeplink: https://dashboard.render.com/blueprint/new?repo=https://github.com/awongCM/wiki-react-redux
3. Set `MONGODB_URI` when prompted
4. Click **Apply**

### Option B: Render MCP

With Render MCP configured and a workspace selected, create the service with:

```
create_web_service(
  name: "wiki-react-redux",
  runtime: "node",
  repo: "https://github.com/awongCM/wiki-react-redux",
  buildCommand: "yarn install && yarn build",
  startCommand: "NODE_ENV=production node server.js",
  plan: "free"
)
```

Then set `MONGODB_URI` via `update_environment_variables`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f58f9-8ee4-713d-b203-138db5202005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f58f9-8ee4-713d-b203-138db5202005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

